### PR TITLE
19: Added Enter plant input box to frontent

### DIFF
--- a/frontend/src/views/Today.test.tsx
+++ b/frontend/src/views/Today.test.tsx
@@ -50,7 +50,7 @@ describe('Today', () => {
         });
       })
 
-      it('', async () => {
+      it('submits plant when entered', async () => {
         const userId = '67bc93477fcac69fbfe17d44';
         const plantId = '67bdca3d86bc1187fad97937';
 
@@ -74,6 +74,28 @@ describe('Today', () => {
               method: 'POST',
             }
           );
+        })
+      })
+
+      it('displays error and does not submit plant when nothing is entered', async () => {
+
+        render(<Today />);
+
+        const inputField = screen.getByLabelText('enter-plant');
+        const submitButton = screen.getByRole('button', { name: /Submit/i });
+
+        act(() => {
+          fireEvent.change(inputField, { target: { value: '' } });
+          fireEvent.click(submitButton);
+        })
+
+        await waitFor(() => {
+          expect(global.fetch).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              method: "POST"
+            })
+          );
+          expect(screen.getByText('Error, must enter a plant before submitting'))
         })
       })
 })

--- a/frontend/src/views/Today.test.tsx
+++ b/frontend/src/views/Today.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Today } from './Today';
 
 describe('Today', () => {
@@ -48,5 +48,32 @@ describe('Today', () => {
         await waitFor(() => {
           expect(screen.getByText('Error fetching plants')).toBeInTheDocument();
         });
+      })
+
+      it('', async () => {
+        const userId = '67bc93477fcac69fbfe17d44';
+        const plantId = '67bdca3d86bc1187fad97937';
+
+        render(<Today />);
+
+        const inputField = screen.getByLabelText('enter-plant');
+        const submitButton = screen.getByRole('button', { name: /Submit/i });
+
+        act(() => {
+          fireEvent.change(inputField, { target: { value: 'apple' } });
+          fireEvent.click(submitButton);
+        })
+
+        await waitFor(() => {
+          expect(global.fetch).toHaveBeenCalledWith(
+            `${process.env.REACT_APP_BASE_URL}/user/${userId}/add-plant/${plantId}`,
+            {
+              headers: {
+                'Access-Control-Allow-Origin': process.env.REACT_APP_ORIGIN ?? '',
+              },
+              method: 'POST',
+            }
+          );
+        })
       })
 })

--- a/frontend/src/views/Today.tsx
+++ b/frontend/src/views/Today.tsx
@@ -5,10 +5,12 @@ import '../App.css';
 export function Today() {
     const [plants, setPlants] = useState<Plant[]>([]);
     const [isError, setIsError] = useState(false);
+    const [enteredPlant, setEnteredPlant] = useState('');
     // TODO: need to get the userId somehow - probably taken from the url and saved into the state.
 
   useEffect(() => {
     const fetchPlants = async () => {
+      //TODO: Needs error handling if fetch fails
       const data = await fetch(`${process.env.REACT_APP_BASE_URL}/user/67bc93477fcac69fbfe17d44/plants?when=today`, {
         headers: {
           'Access-Control-Allow-Origin': process.env.REACT_APP_ORIGIN ?? ''
@@ -43,10 +45,28 @@ export function Today() {
       )
   }
 
+  async function submitPlant() {
+    //TODO: Needs to retrieve the correct plant_id
+    //TODO: Needs error handling if fetch fails
+    await fetch(`${process.env.REACT_APP_BASE_URL}/user/67bc93477fcac69fbfe17d44/add-plant/67bdca3d86bc1187fad97937`, {
+      headers: {
+        'Access-Control-Allow-Origin': process.env.REACT_APP_ORIGIN ?? ''
+      },
+      method: 'POST'
+    })
+  }
+
   return (
     <div className="App" data-testid="today-view">
     <header className="App-header">
       <h2>Number of plants eaten today: {plants.length}</h2>
+      <form>
+        <label>
+          Enter plant:
+          <input type="text" aria-label="enter-plant" value={enteredPlant} onChange={(event) => setEnteredPlant(event.target.value)} />
+        </label>
+        <button type="submit" onClick={submitPlant}>Submit</button>
+      </form>
       <h2>Plants eaten today:</h2>
       { listPlants() }
     </header>

--- a/frontend/src/views/Today.tsx
+++ b/frontend/src/views/Today.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 import { Plant } from '../types';
 import '../App.css';
 
@@ -6,6 +6,7 @@ export function Today() {
     const [plants, setPlants] = useState<Plant[]>([]);
     const [isError, setIsError] = useState(false);
     const [enteredPlant, setEnteredPlant] = useState('');
+    const [enteredPlantError, setEnteredPlantError] = useState('')
     // TODO: need to get the userId somehow - probably taken from the url and saved into the state.
 
   useEffect(() => {
@@ -45,9 +46,17 @@ export function Today() {
       )
   }
 
-  async function submitPlant() {
+  async function submitPlant(event: MouseEvent<HTMLButtonElement>) {
     //TODO: Needs to retrieve the correct plant_id
     //TODO: Needs error handling if fetch fails
+
+    event.preventDefault();
+
+    if (!enteredPlant) {
+      setEnteredPlantError('Error, must enter a plant before submitting')
+      return;
+    }
+    setEnteredPlantError('')
     await fetch(`${process.env.REACT_APP_BASE_URL}/user/67bc93477fcac69fbfe17d44/add-plant/67bdca3d86bc1187fad97937`, {
       headers: {
         'Access-Control-Allow-Origin': process.env.REACT_APP_ORIGIN ?? ''
@@ -65,8 +74,9 @@ export function Today() {
           Enter plant:
           <input type="text" aria-label="enter-plant" value={enteredPlant} onChange={(event) => setEnteredPlant(event.target.value)} />
         </label>
-        <button type="submit" onClick={submitPlant}>Submit</button>
+        <button type="submit" onClick={(event) => submitPlant(event)}>Submit</button>
       </form>
+      {enteredPlantError && <p>{enteredPlantError}</p>}
       <h2>Plants eaten today:</h2>
       { listPlants() }
     </header>


### PR DESCRIPTION
An enter plant input box was added to the Today view. It submits a plant to the database using the add_plant() endpoint. If blank plant is submitted a message is displayed to the user.

<img width="725" alt="Screenshot 2025-03-24 at 15 41 38" src="https://github.com/user-attachments/assets/d29855ec-62ee-47e8-9b26-7397b6b53d3b" />

It currently always submits a carrot to a static user. These will be updated to be dynamic in future tickets.