### PR TITLE
59 fe search plants

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -30,9 +30,20 @@ async def create_plant(plant: Plant):
     return Plant(**created_plant)
 
 
-@app.get("/plants/all")
-async def get_all_plants():
-    plants = await app.mongodb["plants"].find({}).to_list(1000)
+@app.get("/plants/search")
+async def search_all_plants(q: str):
+    plants = (
+        await app.mongodb["plants"]
+        .find(
+            {
+                "$or": [
+                    {"name": {"$regex": q, "$options": "i"}},
+                    {"category": {"$regex": q, "$options": "i"}},
+                ]
+            }
+        )
+        .to_list(10)
+    )
 
     for plant in plants:
         plant["_id"] = str(plant["_id"])

--- a/backend/src/tests/test_main.py
+++ b/backend/src/tests/test_main.py
@@ -39,15 +39,19 @@ async def test_create_plant(client):
     assert response.json() == {"_id": id, "name": "apple", "category": "fruit"}
 
 
-async def test_get_all_plants(client, mock_mongo):
+async def test_search_all_plants(client, mock_mongo):
     plant_data = {"name": "apple", "category": "fruit"}
     await mock_mongo.db["plants"].insert_one(plant_data)
 
-    response = client.get("/plants/all")
+    response = client.get("/plants/search?q=ap")
     plant_id = response.json()[0]["_id"]
 
     assert response.status_code == 200
     assert response.json() == [{"_id": plant_id, "name": "apple", "category": "fruit"}]
+
+    response = client.get("/plants/search?q=banana")
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 async def test_add_plant(client, mock_mongo):

--- a/frontend/src/components/EnterPlantInput.test.tsx
+++ b/frontend/src/components/EnterPlantInput.test.tsx
@@ -1,29 +1,38 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EnterPlantInput } from "./EnterPlantInput";
+import userEvent from "@testing-library/user-event";
 
 describe('EnterPlantInput', () => {
 
     beforeEach(() => {
-        (global.fetch as jest.Mock) = jest.fn();
+        (global.fetch as jest.Mock) = jest.fn(() =>
+          Promise.resolve({
+            json: () => Promise.resolve([
+              { _id: 1, name: 'apple' },
+              { _id: 2, name: 'pear' },
+            ]),
+          })
+        );
       })
 
     it('submits plant when entered', async () => {
         const userId = '67bc93477fcac69fbfe17d44';
-        const plantId = '67bdca3d86bc1187fad97937';
 
         render(<EnterPlantInput />);
 
-        const inputField = screen.getByLabelText('enter-plant');
-        const submitButton = screen.getByRole('button', { name: /Submit/i });
-
         act(() => {
-          fireEvent.change(inputField, { target: { value: 'apple' } });
-          fireEvent.click(submitButton);
+          const inputField = screen.getByLabelText('enter-plant');
+          fireEvent.click(inputField);
+        })
+
+        waitFor(() => {
+          const appleListItem = screen.getByText('apple');
+          fireEvent.click(appleListItem);
         })
 
         await waitFor(() => {
           expect(global.fetch).toHaveBeenCalledWith(
-            `${process.env.REACT_APP_BASE_URL}/user/${userId}/add-plant/${plantId}`,
+            `${process.env.REACT_APP_BASE_URL}/user/${userId}/add-plant/1`,
             {
               headers: {
                 'Access-Control-Allow-Origin': process.env.REACT_APP_ORIGIN ?? '',
@@ -31,28 +40,6 @@ describe('EnterPlantInput', () => {
               method: 'POST',
             }
           );
-        })
-      })
-
-      it('displays error and does not submit plant when nothing is entered', async () => {
-
-        render(<EnterPlantInput />);
-
-        const inputField = screen.getByLabelText('enter-plant');
-        const submitButton = screen.getByRole('button', { name: /Submit/i });
-
-        act(() => {
-          fireEvent.change(inputField, { target: { value: '' } });
-          fireEvent.click(submitButton);
-        })
-
-        await waitFor(() => {
-          expect(global.fetch).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-              method: "POST"
-            })
-          );
-          expect(screen.getByText('Error, must enter a plant before submitting')).toBeInTheDocument();
         })
       })
 });

--- a/frontend/src/components/EnterPlantInput.test.tsx
+++ b/frontend/src/components/EnterPlantInput.test.tsx
@@ -95,4 +95,32 @@ describe('EnterPlantInput', () => {
           expect(screen.getByText('Error fetching plants')).toBeVisible();
         });
       });
+
+      it('submits a plant on pressing Enter or Space on a dropdown item', async () => {
+        render(<EnterPlantInput />);
+
+        // Open the dropdown
+        const inputField = screen.getByLabelText('enter-plant');
+        fireEvent.click(inputField);
+
+        // Wait for the dropdown to appear
+        await waitFor(() => {
+          screen.getByText('apple');
+        });
+
+        const appleListItem = screen.getByText('apple');
+
+        // Focus the list item (important for keyboard events)
+        appleListItem.focus();
+
+        // Simulate pressing Enter
+        fireEvent.keyDown(appleListItem, { key: 'Enter', code: 'Enter' });
+
+        await waitFor(() => {
+          expect(global.fetch).toHaveBeenCalledWith(
+            `${process.env.REACT_APP_BASE_URL}/user/67bc93477fcac69fbfe17d44/add-plant/1`,
+            expect.any(Object)
+          );
+        });
+      });
 });

--- a/frontend/src/components/EnterPlantInput.test.tsx
+++ b/frontend/src/components/EnterPlantInput.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EnterPlantInput } from "./EnterPlantInput";
-import userEvent from "@testing-library/user-event";
 
 describe('EnterPlantInput', () => {
 

--- a/frontend/src/components/EnterPlantInput.tsx
+++ b/frontend/src/components/EnterPlantInput.tsx
@@ -33,7 +33,6 @@ export function EnterPlantInput() {
     }, [enteredPlant]);
 
   useEffect(() => {
-    console.log(closeDropDownOnClick)
     const closeDropDownOnClickFn = (event: any) => {
       if(dropDownOpen && !closeDropDownOnClick.current?.contains(event.target)) {
         setDropDownOpen(false)
@@ -71,7 +70,7 @@ export function EnterPlantInput() {
         {enteredPlantError && <p>{enteredPlantError}</p>}
         {isError && <p>Error fetching plants</p>}
         {dropDownOpen &&
-        <ul className="dropdown">
+        <ul className="dropdown" data-testid="plant-dropdown">
           { plantList.map((plant) => {
             return <li key={plant._id} className="dropdown-items"><a onClick={() => submitPlant(plant)}>{ plant.name }</a></li>
           }) }

--- a/frontend/src/components/EnterPlantInput.tsx
+++ b/frontend/src/components/EnterPlantInput.tsx
@@ -1,8 +1,33 @@
-import { useState, MouseEvent } from "react";
+import { useState, MouseEvent, useEffect } from "react";
+import { Plant } from "../types";
 
 export function EnterPlantInput() {
+    const [plantList, setPlantList] = useState<Plant[]>([]);
+    const [isError, setIsError] = useState(false);
     const [enteredPlant, setEnteredPlant] = useState('');
     const [enteredPlantError, setEnteredPlantError] = useState('')
+
+    useEffect(() => {
+      const fetchPlants = async () => {
+        //TODO: Needs error handling if fetch fails
+        const data = await fetch(`${process.env.REACT_APP_BASE_URL}/plants/search?q=${enteredPlant}`, {
+          headers: {
+            'Access-Control-Allow-Origin': process.env.REACT_APP_ORIGIN ?? ''
+          }
+        })
+        return await data.json()
+      }
+
+      fetchPlants()
+      .then((data) => {
+        setPlantList(data)
+        setIsError(false)
+      })
+      .catch((error) => {
+        console.log(error);
+        setIsError(true)
+      })
+    }, [enteredPlant]);
 
     async function submitPlant(event: MouseEvent<HTMLButtonElement>) {
         //TODO: Needs to retrieve the correct plant_id
@@ -32,6 +57,12 @@ export function EnterPlantInput() {
                 <button type="submit" onClick={(event) => submitPlant(event)}>Submit</button>
             </form>
         {enteredPlantError && <p>{enteredPlantError}</p>}
+        {isError && <p>Error fetching plants</p>}
+        <ul>
+          { plantList.map((plant) => {
+            return <li key={plant._id}>{ plant.name }</li>
+          }) }
+        </ul>
       </div>
     )
 }

--- a/frontend/src/components/EnterPlantInput.tsx
+++ b/frontend/src/components/EnterPlantInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, KeyboardEvent } from "react";
 import { Plant } from "../types";
 
 export function EnterPlantInput() {
@@ -49,6 +49,17 @@ export function EnterPlantInput() {
       setDropDownOpen(false)
     }
 
+    function handlePlantItemClick(plant: Plant) {
+      submitPlant(plant);
+    }
+
+    function handlePlantItemKeyDown(event: KeyboardEvent<HTMLLIElement>, plant: Plant) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        submitPlant(plant);
+      }
+    }
+
     async function submitPlant(plant: Plant) {
       closeDropDown();
       setEnteredPlant("")
@@ -71,7 +82,7 @@ export function EnterPlantInput() {
         {dropDownOpen &&
         <ul className="dropdown" data-testid="plant-dropdown">
           { plantList.map((plant) => {
-            return <li key={plant._id} className="dropdown-items"><a onClick={() => submitPlant(plant)}>{ plant.name }</a></li>
+            return <li key={plant._id} className="dropdown-items" onClick={() => handlePlantItemClick(plant) } onKeyDown={(event) => handlePlantItemKeyDown(event, plant)}>{ plant.name }</li>
           }) }
         </ul>
 }

--- a/frontend/src/components/EnterPlantInput.tsx
+++ b/frontend/src/components/EnterPlantInput.tsx
@@ -1,11 +1,11 @@
-import { useState, MouseEvent, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Plant } from "../types";
 
 export function EnterPlantInput() {
     const [plantList, setPlantList] = useState<Plant[]>([]);
     const [isError, setIsError] = useState(false);
     const [enteredPlant, setEnteredPlant] = useState('');
-    const [enteredPlantError, setEnteredPlantError] = useState('')
+    // const [enteredPlantError, setEnteredPlantError] = useState('')
     const [dropDownOpen, setDropDownOpen] = useState(false)
 
     const closeDropDownOnClick = useRef<HTMLInputElement>(null);
@@ -65,9 +65,8 @@ export function EnterPlantInput() {
         <div ref={closeDropDownOnClick}>
             <form>
               <input type="text" aria-label="enter-plant" placeholder='Search for plant' value={enteredPlant} onChange={(event) => setEnteredPlant(event.target.value)} onClick={openDropDown}/>
-                {/* <button type="submit" onClick={(event) => submitPlant(event)}>Submit</button> */}
             </form>
-        {enteredPlantError && <p>{enteredPlantError}</p>}
+        {/* {enteredPlantError && <p>{enteredPlantError}</p>} */}
         {isError && <p>Error fetching plants</p>}
         {dropDownOpen &&
         <ul className="dropdown" data-testid="plant-dropdown">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,28 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+.dropdown {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  color: black;
+}
+
+.dropdown-items {
+  padding: 0.5rem;
+  margin: 0.1rem;
+  /* width: 100%; */
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.dropdown-items:hover {
+  background-color: rgb(240, 240, 240);
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 export interface Plant {
-    id: string;
+    _id: string;
     name: string;
     category: string
 }

--- a/frontend/src/views/Today.test.tsx
+++ b/frontend/src/views/Today.test.tsx
@@ -8,8 +8,8 @@ describe('Today', () => {
         (global.fetch as jest.Mock) = jest.fn(() =>
           Promise.resolve({
             json: () => Promise.resolve([
-              { id: 1, name: 'rice' },
-              { id: 2, name: 'onion' },
+              { _id: 1, name: 'rice' },
+              { _id: 2, name: 'onion' },
             ]),
           })
         );
@@ -46,7 +46,7 @@ describe('Today', () => {
         render(<Today />);
 
         await waitFor(() => {
-          expect(screen.getByText('Error fetching plants')).toBeInTheDocument();
+          expect(screen.getByText('Error fetching the plants you have eaten today')).toBeInTheDocument();
         });
       })
 })

--- a/frontend/src/views/Today.tsx
+++ b/frontend/src/views/Today.tsx
@@ -30,7 +30,7 @@ export function Today() {
 
   function listPlants() {
     if (isError) {
-      return (<p>Error fetching plants</p>)
+      return (<p>Error fetching the plants you have eaten today</p>)
     }
 
     if (plants.length === 0) {

--- a/frontend/src/views/Today.tsx
+++ b/frontend/src/views/Today.tsx
@@ -40,7 +40,7 @@ export function Today() {
     return (
       <ul>
         { plants.map((plant) => {
-          return <li key={plant.id}>{ plant.name }</li>
+          return <li key={plant._id}>{ plant.name }</li>
         }) }
       </ul>
       )


### PR DESCRIPTION
Updated the enter plant input box:
- removed the submit button and Enter Plant label, and added placeholder text in the inputbox
- on click a dropdown menu appears
- a search query is run on the plants collection, returning a maximum of 10 results
- as letters are entered into the inputbox search queries are run against the plants collection using the search endpoint return results that fit the letters
- When an item in the dropdown box is clicked, that item is submitted to the user/:userId/plants/:plant_id endpoint.
- A little bit of styling was done for the dropbox (but still more needs doing).

<img width="747" alt="Screenshot 2025-03-27 at 15 28 12" src="https://github.com/user-attachments/assets/350eb97c-2381-4d03-99a9-ca948fdba28b" />
