### PR TITLE
78: added validation to create plant to check if plant already exists

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -22,6 +22,15 @@ app.add_middleware(
 
 @app.post("/create-plant", response_model=Plant, status_code=201)
 async def create_plant(plant: Plant):
+    is_plant_in_db = await app.mongodb["plants"].count_documents(
+        {"name": {"$regex": plant.name, "$options": "i"}}
+    )
+
+    if is_plant_in_db > 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Plant already exists"
+        )
+
     new_plant = await app.mongodb["plants"].insert_one(
         plant.model_dump(by_alias=True, exclude=["id"])
     )

--- a/backend/src/tests/test_main.py
+++ b/backend/src/tests/test_main.py
@@ -40,6 +40,20 @@ async def test_create_plant(client):
     assert response.json() == {"_id": id, "name": "apple", "category": "fruit"}
 
 
+async def test_create_plant_already_exists(client, mock_mongo):
+    plant_data = {
+        "_id": "64e10a1b9d708654778a1337",
+        "name": "apple",
+        "category": "fruit",
+    }
+    await mock_mongo.db["plants"].insert_one(plant_data)
+
+    response = client.post("/create-plant", json={"name": "apple", "category": "fruit"})
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Plant already exists"}
+
+
 async def test_search_all_plants(client, mock_mongo):
     plant_data = {"name": "apple", "category": "fruit"}
     await mock_mongo.db["plants"].insert_one(plant_data)


### PR DESCRIPTION
Added validation to the `create_plant()` to check if the plant being added already exists in the database. If it does a 409 is returned to the client.