### PR TITLE
155: Fixed regex in create_plant endpoint

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -137,7 +137,7 @@ async def verify_authorisation(body: AuthorizationResponse, response: Response):
 @app.post("/create-plant", response_model=Plant, status_code=201)
 async def create_plant(plant: Plant, user_id: str = Depends(get_current_user)):
     is_plant_in_db = await app.mongodb["plants"].count_documents(
-        {"name": {"$regex": plant.name, "$options": "i"}}
+        {"name": {"$regex": rf"^{plant.name}$", "$options": "i"}}
     )
 
     if is_plant_in_db > 0:


### PR DESCRIPTION
Created unit test to test that potato can be created when sweet potato exists in db:
<img width="1004" alt="Screenshot 2025-04-14 at 10 28 17" src="https://github.com/user-attachments/assets/5561e4d2-927b-4111-9e65-21e7661bece3" />

And test passes once code is fixed:
<img width="988" alt="Screenshot 2025-04-14 at 10 29 05" src="https://github.com/user-attachments/assets/635f7351-d0c6-43dc-8b1c-37785a3ef3e7" />
