### PR TITLE
153: Updated add_plant endpoint to accept any date

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,3 +6,4 @@ sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
 sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/test_*.py
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
 sonar.python.coverage.reportPaths=backend/coverage.xml
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/test_*.py


### PR DESCRIPTION
Add plant endpoint now accepts the when values: today, yesterday and a past date in 'dd-mm-yyyy' format.